### PR TITLE
Initial prototype and StochasticTransformations

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,5 @@
 julia 0.4
+LearnBase
 Reexport
+Distributions
+StatsBase

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.4
+Reexport

--- a/src/Transformations.jl
+++ b/src/Transformations.jl
@@ -1,5 +1,54 @@
 module Transformations
 
-# package code goes here
+## Dependencies ##
+
+using Reexport
+@reexport using LearnBase
+
+import StatsBase:
+    # functions
+    logistic,
+    logit
+
+import Distributions:
+    # probability distributions
+    Distribution,
+    Normal,
+    Bernoulli,
+    NegativeBinomial,
+    Poisson
+
+## Exported types ##
+
+export
+    # static transformations
+    IdentityTransformation,
+    LogTransformation,
+    ExpTransformation,
+    LogisticTransformation,
+    LogitTransformation,
+    ScaleTransformation,
+    ShiftTransformation,
+
+    # stochastic transformations
+    GaussianTransformation,
+    PoissonTransformation,
+    BernoulliTransformation,
+    NegativeBinomialTransformation,
+    GeneralizedLinearTransformation
+
+## Exported functions ##
+# TODO: should these be defined in LearnBase?
+export invert, invert!,
+       get_inverse, isinvertible
+
+include("common.jl")
+include("static.jl")
+include("stochastic.jl")
+include("glt.jl")
+
+# TODO: Need to decide conventions for learned transformations.
+# include("learned.jl")
+# include("sequence.jl")
 
 end # module

--- a/src/Transformations.jl
+++ b/src/Transformations.jl
@@ -39,8 +39,7 @@ export
 
 ## Exported functions ##
 # TODO: should these be defined in LearnBase?
-export invert, invert!,
-       get_inverse, isinvertible
+export invert, invert!, isinvertible
 
 include("common.jl")
 include("static.jl")

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,0 +1,9 @@
+function transform{T<:Transformation, A<:AbstractArray}(tfm::T, x::A)
+    y = copy(x)
+    transform!(tfm, y)
+end
+
+function invert{T<:Transformation, A<:AbstractArray}(tfm::T, x::A)
+    y = copy(x)
+    invert!(tfm, y)
+end

--- a/src/glt.jl
+++ b/src/glt.jl
@@ -1,0 +1,34 @@
+"""
+Transformation associated with a Generalized Linear Model (GLM). Maps an input
+`x` to a random variable with expected value equal to `g(x)` where g(⋅) is a
+inverse link function.
+"""
+immutable GeneralizedLinearTransformation{ST<:StochasticTransformation}
+    noise::ST
+    invlink::Transformation
+end
+
+# constructors
+function GeneralizedLinearTransformation{D<:Distribution}(d::D)
+    tfm = StochasticTransformation(d)
+    invlink = cannonical_inv_link(d)
+    GeneralizedLinearTransformation(tfm,invlink)
+end
+function GeneralizedLinearTransformation{D<:Distribution, T<:Transformation}(d::D, invlink::T)
+    tfm = StochasticTransformation(d)
+    GeneralizedLinearTransformation(tfm,invlink)
+end
+
+# functions
+function transform(tfm::GeneralizedLinearTransformation, x)
+    transform(tfm.noise, transform(tfm.invlink, x))
+end
+function rand(tfm::GeneralizedLinearTransformation, x)
+    rand(tfm.noise, transform(tfm.invlink, x))
+end
+
+# cannonical inverse link functions
+cannonical_inv_link(::Normal) = IdentityTransformation()
+cannonical_inv_link(::Bernoulli) = LogisticTransformation()
+cannonical_inv_link(::Poisson) = ExpTransformation()
+cannonical_inv_link(::NegativeBinomial) = ExpTransformation()

--- a/src/learned.jl
+++ b/src/learned.jl
@@ -11,20 +11,24 @@ end
 learn!(tfm::CenteringTransformation, x) = (tfm.shift = mean(x); tfm)
 transform!(tfm::CenteringTransformation, x) = (transform!(tfm.shift, x); x)
 invert!(tfm::CenteringTransformation, x) = (invert!(tfm.shift, x); x)
+## What should this return ??
+# Base.inv(tfm::CenteringTransformation) = ??? 
 
-type Standardize{T<:Real}
+type StandardizeTransformation{T<:Real}
     shift::ShiftTransformation{T}
     scale::ScaleTransformation{T}
 end
-function learn!{T}(tfm::Standardize{T}, x)
+function learn!{T}(tfm::StandardizeTransformation{T}, x)
     tfm.shift = mean(x)
     tfm.scale = one(T)/std(x)
 end
-function transform!(tfm::Standardize, x)
+function transform!(tfm::StandardizeTransformation, x)
     transform!(tfm.shift, x)
     transform!(tfm.scale, x)
 end
-function invert!(tfm::Standardize, x)
+function invert!(tfm::StandardizeTransformation, x)
     invert!(tfm.scale, x)
     invert!(tfm.shift, x)
 end
+## What should this return ??
+# Base.inv(tfm::StandardizeTransformation) = ??? 

--- a/src/learned.jl
+++ b/src/learned.jl
@@ -1,0 +1,30 @@
+##--- Learnable Transforms ---##
+
+type CenteringTransformation{T<:Real}
+    shift::ShiftTransform{T}
+end
+CenteringTransformation() = CenteringTransformation(ShiftTransform())
+function CenteringTransformation(x::AbstractArray)
+    tfm = CenteringTransformation()
+    learn!(tfm, x)
+end
+learn!(tfm::CenteringTransformation, x) = (tfm.shift = mean(x); tfm)
+transform!(tfm::CenteringTransformation, x) = (transform!(tfm.shift, x); x)
+invert!(tfm::CenteringTransformation, x) = (invert!(tfm.shift, x); x)
+
+type Standardize{T<:Real}
+    shift::ShiftTransformation{T}
+    scale::ScaleTransformation{T}
+end
+function learn!{T}(tfm::Standardize{T}, x)
+    tfm.shift = mean(x)
+    tfm.scale = one(T)/std(x)
+end
+function transform!(tfm::Standardize, x)
+    transform!(tfm.shift, x)
+    transform!(tfm.scale, x)
+end
+function invert!(tfm::Standardize, x)
+    invert!(tfm.scale, x)
+    invert!(tfm.shift, x)
+end

--- a/src/sequence.jl
+++ b/src/sequence.jl
@@ -1,0 +1,17 @@
+immutable TransformSequence{N,T}
+    pipeline::NTuple{N,T}
+end
+function transform!(transform::TransformSequence, x)
+    for tfm in transform.pipeline
+        transform!(tfm,x)
+    end
+end
+
+function invert!(transform::TransformSequence, x)
+    for tfm in reverse(transform.pipeline)
+        !invertible(tfm) && error("transform not invertible")
+    end
+    for tfm in reverse(transform.pipeline)
+        invert!(tfm,x)
+    end
+end

--- a/src/static.jl
+++ b/src/static.jl
@@ -1,0 +1,56 @@
+##--- Identity ---##
+type IdentityTransformation <: Transformation end
+transform!(::IdentityTransformation, x) = x
+invert!(::IdentityTransformation, x) = x
+transform(::IdentityTransformation, x) = copy(x)
+invert(::IdentityTransformation, x) = copy(x)
+isinvertible(::IdentityTransformation) = true
+
+##--- Invertible Transforms ---##
+for (t1,f1,t2,f2) in ( (:ExpTransformation, :exp, :LogTransformation, :log),
+                       (:LogisticTransformation, :logistic, :LogitTransformation, :logit) )
+    @eval begin
+        type $(t1) <: Transformation end
+        type $(t2) <: Transformation end
+        transform!(::$(t1), x) = map!($(f1),x)
+        transform!(::$(t2), x) = map!($(f2),x)
+        transform(::$(t1), x) = $(f1)(x)
+        transform(::$(t2), x) = $(f2)(x)
+        invert!(::$(t1), x) = map!($(f2),x)
+        invert!(::$(t2), x) = map!($(f1),x)
+        invert(::$(t1), x) = $(f2)(x)
+        invert(::$(t2), x) = $(f1)(x)
+        get_inverse(::$(t1)) = $(t2)()
+        get_inverse(::$(t2)) = $(t1)()
+        isinvertible(::$(t1)) = true
+        isinvertible(::$(t2)) = true
+    end
+end
+
+## --- Scaling --- ##
+immutable ScaleTransformation{T<:Number} <: Transformation
+    val::T
+end
+ScaleTransformation() = ScaleTransformation(1.0)
+isinvertible(::ScaleTransformation) = true
+function invert!{T}(transform::ScaleTransformation{T}, x::AbstractArray{T})
+    scale!(one(T)/transform.val, x)
+end
+function transform!{T}(transform::ScaleTransformation, x::AbstractArray{T})
+    scale!(transform.val, x)
+end
+
+## --- Shifting --- ##
+immutable ShiftTransformation{T<:Number} <: Transformation
+    val::T
+end
+ShiftTransformation() = ShiftTransformation(0.0)
+isinvertible(::ShiftTransformation) = true
+function transform!{T}(transform::ShiftTransformation{T}, x::AbstractArray{T})
+    for i in eachindex(x); x[i] += transform.val; end
+    x
+end
+function invert!{T}(transform::ShiftTransformation{T}, x::AbstractArray{T})
+    for i in eachindex(x); x[i] -= transform.val; end
+    x
+end

--- a/src/stochastic.jl
+++ b/src/stochastic.jl
@@ -1,0 +1,99 @@
+# # TODO -- find a better home for Domains (or delete them...)
+# abstract Domain
+
+# immutable RealDomain <: Domain end
+# Base.in(x,::Type{RealDomain}) = typeof(x) <: Real
+
+# immutable NonNegRealDomain <: Domain end
+# Base.in(x,::Type{NonNegRealDomain}) = (typeof(x) <: Real && x >= 0)
+
+# domain(::GaussianTransformation) = Real
+# domain(::PoissonTransformation) = NonNegRealDomain
+
+## GAUSSIAN ##
+"""
+    tfm = GaussianTransformation(σ)
+
+Adds zero-mean gaussian noise to an input variable x with standard deviation σ.
+
+X -> ξ,  ξ ∼ N(X,σ)
+"""
+immutable GaussianTransformation{T<:Real} <: StochasticTransformation
+    σ::T
+end
+
+# constructors
+"""
+Adds zero-mean gaussian noise to an input variable x with standard deviation σ.
+
+X -> ξ,  ξ ∼ N(X,σ)
+"""
+GaussianTransformation(d::Normal) = GaussianTransformation(d.σ)
+GaussianTransformation() = GaussianTransformation(1.0)
+Transformation(d::Normal) = GaussianTransformation(d.σ)
+StochasticTransformation(d::Normal) = GaussianTransformation(d.σ)
+
+# functions
+Base.rand(tfm::GaussianTransformation, x) = x + randn()*tfm.σ
+transform(tfm::GaussianTransformation, x) = Normal(x,tfm.σ)
+
+
+## POISSON ##
+"""
+Transform a non-negative variable, x, into poisson random variable with mean x.
+
+x -> ξ,  ξ ∼ Poisson(x)
+"""
+immutable PoissonTransformation <: StochasticTransformation end
+
+# constructors
+Transformation(d::Poisson) = PoissonTransformation()
+StochasticTransformation(d::Poisson) = PoissonTransformation()
+
+# functions
+Base.rand(::PoissonTransformation, x) = rand(Poisson(x))
+transform(::PoissonTransformation, x) = Poisson(x)
+
+
+## BERNOULLI ##
+"""
+Transform an input 0 ≤ x ≤ 1 into a Bernoulli random variable with mean x.
+
+x -> ξ,  ξ ∼ Bernoulli(x)
+"""
+immutable BernoulliTransformation <: StochasticTransformation end
+
+# constructors
+Transformation(d::Bernoulli) = BernoulliTransformation()
+StochasticTransformation(d::Bernoulli) = BernoulliTransformation()
+
+# functions
+Base.rand(::BernoulliTransformation, x) = rand(Bernoulli(x))
+transform(::BernoulliTransformation, x) = Bernoulli(x)
+
+
+## NEGATIVE BINOMIAL ##
+"""
+Transform a non-negative variable, x, into a negative binomial random variable
+with mean x and (fixed) variance σ²
+
+x -> ξ,  ξ ∼ NegativeBinomial,  E{ξ} = x
+"""
+immutable NegativeBinomialTransformation{T<:Real} <: StochasticTransformation 
+    σ²::T
+end
+
+# constructors
+Transformation(d::NegativeBinomial) = NegativeBinomialTransformation(var(d))
+StochasticTransformation(d::NegativeBinomial) = NegativeBinomialTransformation(var(d))
+NegativeBinomialTransformation(d::NegativeBinomial) = NegativeBinomialTransformation(var(d))
+NegativeBinomialTransformation() = NegativeBinomialTransformation(1.0)
+
+# functions
+function specify_moments(::Type{NegativeBinomial},μ,σ²)
+    p = μ / σ²
+    r = μ*p / (1.0-p)
+    return NegativeBinomial(r,p)
+end
+Base.rand(tfm::NegativeBinomialTransformation, x) = rand(specify_moments(NegBinomial,x,tfm.σ²))
+transform(tfm::NegativeBinomialTransformation, x) = specify_moments(NegBinomial,x,tfm.σ²)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,6 +19,12 @@ s = 2.3
 tfm = ScaleTransformation(s)
 @test isapprox(xv*s, transform(ScaleTransformation(s), xv))
 @test isapprox(xv+s, transform(ShiftTransformation(s), xv))
+
+tfm = ShiftTransformation(s)
+y = transform(tfm, xv)
+@test isapprox(xv, transform(inv(tfm), y))
+@test isapprox(xv, invert(tfm, y))
+
 #@test isapprox(xv-mean(xv), transform(CenteringTransformation(xv),xv))
 
 ## Generalized Linear Transform ##

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,32 @@
 using Transformations
 using Base.Test
+using Distributions
 
-# write your own tests here
-@test 1 == 1
+## Basic ##
+xv = abs(randn(200,100))+0.1 # array input
+@test isapprox(xv, transform(IdentityTransformation(),xv))
+@test isapprox(log(xv), transform(LogTransformation(),xv))
+@test isapprox(exp(xv), transform(ExpTransformation(),xv))
+
+xs = rand()+0.1 # scalar input
+@test isapprox(xs, transform(IdentityTransformation(),xs))
+@test isapprox(log(xs), transform(LogTransformation(),xs))
+@test isapprox(exp(xs), transform(ExpTransformation(),xs))
+
+## Shifting and Scaling ##
+xv = randn(100)
+s = 2.3
+tfm = ScaleTransformation(s)
+@test isapprox(xv*s, transform(ScaleTransformation(s), xv))
+@test isapprox(xv+s, transform(ShiftTransformation(s), xv))
+#@test isapprox(xv-mean(xv), transform(CenteringTransformation(xv),xv))
+
+## Generalized Linear Transform ##
+μ,σ = 1.0,1.0
+tfm = GeneralizedLinearTransformation(Normal(μ,σ))
+@test Normal(μ,σ) == transform(tfm, μ)
+
+x = -1.0
+λ = exp(x)
+tfm = GeneralizedLinearTransformation(Poisson())
+@test Poisson(λ) == transform(tfm, x)


### PR DESCRIPTION
**Summary:**
- I'm using [Rexport](https://github.com/simonster/Reexport.jl) to automatically export all of `LearnBase`. Does this seem like a good idea?
- I needed a generative model of GLMs for my day job, so I decided to put that here which led me to a prototype of `StochasticTransformation`. See the `glt.jl` file.
  - This introduces a dependency on Distributions.jl
  - `transform(::StochasticTransformation, x)` maps `x` (whatever it is) into a `Distribution`. I personally think this convention makes a lot of sense, but am happy to debate this.
  - `rand(::StochasticTransformation, x)` samples from this final distribution. That is it maps `x` to a random output specified from the transformation.

@Evizero @tbreloff -- how does this sit with you? I am happy to make other changes to this before merging. This was a somewhat rough pass.
